### PR TITLE
fix: replace IconStudioPro with StudioPage in tests and fix ShaderBui…

### DIFF
--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -8,7 +8,7 @@ import 'package:iconic_studio_pro/main.dart';
 void main() {
   group('App launch smoke', () {
     testWidgets('renders key studio UI', (tester) async {
-      await tester.pumpWidget(const IconStudioPro());
+      await tester.pumpWidget(const MaterialApp(home: StudioPage()));
 
       expect(find.text('IconStudio'), findsOneWidget);
       expect(find.text('Export Icon'), findsOneWidget);
@@ -31,7 +31,7 @@ void main() {
 
   group('Export button presence', () {
     testWidgets('export button is present and tappable', (tester) async {
-      await tester.pumpWidget(const IconStudioPro());
+      await tester.pumpWidget(const MaterialApp(home: StudioPage()));
 
       final exportButton = find.widgetWithText(ElevatedButton, 'Export Icon');
       expect(exportButton, findsOneWidget);
@@ -47,8 +47,8 @@ void main() {
         MaterialApp(
           home: Scaffold(
             body: ShaderBuilder(
+              (context, shader, child) => const SizedBox.shrink(),
               assetKey: 'shaders/diamond_master.frag',
-              (context, shader, child) => SizedBox.shrink(),
             ),
           ),
         ),


### PR DESCRIPTION
…lder arg order

Agent-Logs-Url: https://github.com/MoneyMan421/Iconic-studio-pro/sessions/c7e616d1-7856-4b28-ac94-8af769dd


print('updated.a: ${updated.a}');
print('expected: ${0.2}');
print('converted: ${colorChannel(updated.a)}');


And what I do for Google 